### PR TITLE
Fix "extra frame after ending" issue

### DIFF
--- a/lib/src/filling_bar.dart
+++ b/lib/src/filling_bar.dart
@@ -103,8 +103,8 @@ class FillingBar {
   /// Automatically updates the frame asynchronously
   void autoRender() async {
     while (_clock.isRunning) {
-      await Future.delayed(Duration(seconds: 1));
       _render();
+      await Future.delayed(Duration(seconds: 1));
     }
   }
 


### PR DESCRIPTION
This addresses the bug brought up in #6 , opting for a simpler solution though.